### PR TITLE
Modified aurbs to ignore rsync if rsync is not defined

### DIFF
--- a/bin/aurbs
+++ b/bin/aurbs
@@ -413,14 +413,15 @@ try:
 						os.remove(os.path.join(repodir_public(repo_arch), filename))
 			shutil.copyfile(os.path.join(repodir(repo_arch), 'aurstaging.db.tar.gz'), repodb_file)
 			os.symlink('%s.tar.gz' % repodb_name, repodb_link)
-		if 'url' in AurBSConfig().public_repo['rsync']:
-			log.warning("RSyncing to remote location")
-			subproc.ccall([
-				"rsync", "-P", "-rlptgo", "--delete",
-				repodir_public(""), AurBSConfig().public_repo['rsync']['url']],
-				env={"RSYNC_PASSWORD": AurBSConfig().public_repo['rsync'].get('pass', '')},
-				interrupt=signal.SIGINT
-			)
+		if AurBSConfig().public_repo['rsync'] is not None:
+			if 'url' in AurBSConfig().public_repo['rsync']:
+				log.warning("RSyncing to remote location")
+				subproc.ccall([
+					"rsync", "-P", "-rlptgo", "--delete",
+					repodir_public(""), AurBSConfig().public_repo['rsync']['url']],
+					env={"RSYNC_PASSWORD": AurBSConfig().public_repo['rsync'].get('pass', '')},
+					interrupt=signal.SIGINT
+				)
 except FatalError as e:
 	log.error("Fatal Error: %s" % e)
 	sys.exit(1)


### PR DESCRIPTION
If no rsync is defined in aurbs.cfg aurbs fails with failure
```
Traceback (most recent call last):
  File "/usr/bin/aurbs", line 416, in <module>
    if 'url' in AurBSConfig().public_repo['rsync']:
TypeError: argument of type 'NoneType' is not iterable
```
Configuration
```
        rsync:
                # url: aurbs@domain.net::aurbs
                # pass: secretrsyncpwd
```
I have fixed this.